### PR TITLE
feat: Add statistics reporting to all remaining 7 methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Get the current Cocomo session status including current bet, streak, and total profit",
       ),
       createResetTool("cocomo", "Cocomo"),
+      createStatisticsTool("cocomo", "Cocomo"),
 
       // Goodman
       {
@@ -165,6 +166,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Get the current Goodman session status including current bet, step, win streak, and total profit",
       ),
       createResetTool("goodman", "Goodman"),
+      createStatisticsTool("goodman", "Goodman"),
 
       // Labouchere
       {
@@ -272,6 +274,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Get the current D'Alembert session status including current bet and total profit",
       ),
       createResetTool("dalembert", "D'Alembert"),
+      createStatisticsTool("dalembert", "D'Alembert"),
 
       // Fibonacci
       {
@@ -301,6 +304,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Get the current Fibonacci session status including sequence position, current bet, and total profit",
       ),
       createResetTool("fibonacci", "Fibonacci"),
+      createStatisticsTool("fibonacci", "Fibonacci"),
 
       // Paroli
       {
@@ -330,6 +334,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Get the current Paroli session status including current bet, win streak, and total profit",
       ),
       createResetTool("paroli", "Paroli"),
+      createStatisticsTool("paroli", "Paroli"),
 
       // Percentage
       {
@@ -365,6 +370,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Get the current Percentage betting session status including bankroll, current bet, and profit percentage",
       ),
       createResetTool("percentage", "Percentage betting"),
+      createStatisticsTool("percentage", "Percentage betting"),
 
       // Kelly Criterion
       {
@@ -435,6 +441,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Get the current Kelly Criterion session status including bankroll, recommended bet, and statistics",
       ),
       createResetTool("kelly", "Kelly Criterion"),
+      createStatisticsTool("kelly", "Kelly Criterion"),
     ],
   };
 });
@@ -613,6 +620,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         });
       }
 
+      case "cocomo_statistics":
+        return handleStatistics(cocomo.getStatistics());
+
       // Goodman
       case "goodman_init": {
         const { baseUnit } = args as { baseUnit: number };
@@ -670,6 +680,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           cyclesCompleted: state.cyclesCompleted,
         });
       }
+
+      case "goodman_statistics":
+        return handleStatistics(goodman.getStatistics());
 
       // Labouchere
       case "labouchere_init": {
@@ -854,6 +867,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         });
       }
 
+      case "dalembert_statistics":
+        return handleStatistics(dalembert.getStatistics());
+
       // Fibonacci
       case "fibonacci_init": {
         const { baseUnit, maxIndex } = args as { baseUnit: number; maxIndex?: number };
@@ -907,6 +923,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           sessionActive: state.sessionActive,
         });
       }
+
+      case "fibonacci_statistics":
+        return handleStatistics(fibonacci.getStatistics());
 
       // Paroli
       case "paroli_init": {
@@ -964,6 +983,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           cyclesCompleted: state.cyclesCompleted,
         });
       }
+
+      case "paroli_statistics":
+        return handleStatistics(paroli.getStatistics());
 
       // Percentage
       case "percentage_init": {
@@ -1029,6 +1051,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           sessionActive: state.sessionActive,
         });
       }
+
+      case "percentage_statistics":
+        return handleStatistics(percentage.getStatistics());
 
       // Kelly Criterion
       case "kelly_init": {
@@ -1130,6 +1155,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           sessionActive: state.sessionActive,
         });
       }
+
+      case "kelly_statistics":
+        return handleStatistics(kelly.getStatistics());
 
       default:
         throw new Error(`Unknown tool: ${name}`);

--- a/src/methods/__tests__/cocomo.test.ts
+++ b/src/methods/__tests__/cocomo.test.ts
@@ -366,4 +366,89 @@ describe("CocomoMethod", () => {
       expect(state.payoutMultiplier).toBe(3);
     });
   });
+
+  describe("statistics", () => {
+    it("should initialize statistics on session start", () => {
+      cocomo.initSession(10);
+      const stats = cocomo.getStatistics();
+      expect(stats).toBeDefined();
+      expect(stats?.totalGames).toBe(0);
+    });
+
+    it("should update statistics on recordResult", () => {
+      cocomo.initSession(10);
+      cocomo.recordResult("win");
+      const stats = cocomo.getStatistics();
+      expect(stats?.totalGames).toBe(1);
+      expect(stats?.totalWins).toBe(1);
+      expect(stats?.totalLosses).toBe(0);
+    });
+
+    it("should return undefined when statistics not initialized", () => {
+      const cocomo2 = new CocomoMethod();
+      const stats = cocomo2.getStatistics();
+      expect(stats).toBeUndefined();
+    });
+
+    it("should track bet history", () => {
+      cocomo.initSession(10);
+      cocomo.recordResult("win");
+      cocomo.recordResult("loss");
+      const stats = cocomo.getStatistics();
+      expect(stats?.betHistory).toHaveLength(2);
+      expect(stats?.outcomeHistory).toHaveLength(2);
+    });
+
+    it("should return deep copy of history arrays", () => {
+      cocomo.initSession(10);
+      cocomo.recordResult("win");
+      const stats1 = cocomo.getStatistics();
+      const stats2 = cocomo.getStatistics();
+      expect(stats1?.betHistory).toEqual(stats2?.betHistory);
+      expect(stats1?.betHistory).not.toBe(stats2?.betHistory);
+      expect(stats1?.outcomeHistory).not.toBe(stats2?.outcomeHistory);
+    });
+
+    it("should handle undefined history arrays", () => {
+      cocomo.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (cocomo as any).state.statistics = {
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        ...(cocomo as any).state.statistics,
+        betHistory: undefined,
+        outcomeHistory: undefined,
+        bankrollHistory: undefined,
+      };
+      const stats = cocomo.getStatistics();
+      expect(stats?.betHistory).toBeUndefined();
+      expect(stats?.outcomeHistory).toBeUndefined();
+      expect(stats?.bankrollHistory).toBeUndefined();
+    });
+
+    it("should handle defined bankrollHistory", () => {
+      cocomo.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (cocomo as any).state.statistics = {
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        ...(cocomo as any).state.statistics,
+        bankrollHistory: [1000, 1100],
+      };
+      const stats = cocomo.getStatistics();
+      expect(stats?.bankrollHistory).toEqual([1000, 1100]);
+      expect(stats?.bankrollHistory).not.toBe(
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        (cocomo as any).state.statistics.bankrollHistory,
+      );
+    });
+
+    it("should initialize statistics if missing in recordResult", () => {
+      cocomo.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (cocomo as any).state.statistics = undefined;
+      cocomo.recordResult("win");
+      const stats = cocomo.getStatistics();
+      expect(stats).toBeDefined();
+      expect(stats?.totalGames).toBe(1);
+    });
+  });
 });

--- a/src/methods/__tests__/dalembert.test.ts
+++ b/src/methods/__tests__/dalembert.test.ts
@@ -304,4 +304,89 @@ describe("DAlembertMethod", () => {
       expect(state.totalProfit).toBe(40);
     });
   });
+
+  describe("statistics", () => {
+    it("should initialize statistics on session start", () => {
+      dalembert.initSession(10);
+      const stats = dalembert.getStatistics();
+      expect(stats).toBeDefined();
+      expect(stats?.totalGames).toBe(0);
+    });
+
+    it("should update statistics on recordResult", () => {
+      dalembert.initSession(10);
+      dalembert.recordResult("win");
+      const stats = dalembert.getStatistics();
+      expect(stats?.totalGames).toBe(1);
+      expect(stats?.totalWins).toBe(1);
+      expect(stats?.totalLosses).toBe(0);
+    });
+
+    it("should return undefined when statistics not initialized", () => {
+      const dalembert2 = new DAlembertMethod();
+      const stats = dalembert2.getStatistics();
+      expect(stats).toBeUndefined();
+    });
+
+    it("should track bet history", () => {
+      dalembert.initSession(10);
+      dalembert.recordResult("win");
+      dalembert.recordResult("loss");
+      const stats = dalembert.getStatistics();
+      expect(stats?.betHistory).toHaveLength(2);
+      expect(stats?.outcomeHistory).toHaveLength(2);
+    });
+
+    it("should return deep copy of history arrays", () => {
+      dalembert.initSession(10);
+      dalembert.recordResult("win");
+      const stats1 = dalembert.getStatistics();
+      const stats2 = dalembert.getStatistics();
+      expect(stats1?.betHistory).toEqual(stats2?.betHistory);
+      expect(stats1?.betHistory).not.toBe(stats2?.betHistory);
+      expect(stats1?.outcomeHistory).not.toBe(stats2?.outcomeHistory);
+    });
+
+    it("should handle undefined history arrays", () => {
+      dalembert.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (dalembert as any).state.statistics = {
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        ...(dalembert as any).state.statistics,
+        betHistory: undefined,
+        outcomeHistory: undefined,
+        bankrollHistory: undefined,
+      };
+      const stats = dalembert.getStatistics();
+      expect(stats?.betHistory).toBeUndefined();
+      expect(stats?.outcomeHistory).toBeUndefined();
+      expect(stats?.bankrollHistory).toBeUndefined();
+    });
+
+    it("should handle defined bankrollHistory", () => {
+      dalembert.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (dalembert as any).state.statistics = {
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        ...(dalembert as any).state.statistics,
+        bankrollHistory: [1000, 1100],
+      };
+      const stats = dalembert.getStatistics();
+      expect(stats?.bankrollHistory).toEqual([1000, 1100]);
+      expect(stats?.bankrollHistory).not.toBe(
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        (dalembert as any).state.statistics.bankrollHistory,
+      );
+    });
+
+    it("should initialize statistics if missing in recordResult", () => {
+      dalembert.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (dalembert as any).state.statistics = undefined;
+      dalembert.recordResult("win");
+      const stats = dalembert.getStatistics();
+      expect(stats).toBeDefined();
+      expect(stats?.totalGames).toBe(1);
+    });
+  });
 });

--- a/src/methods/__tests__/fibonacci.test.ts
+++ b/src/methods/__tests__/fibonacci.test.ts
@@ -365,4 +365,89 @@ describe("FibonacciMethod", () => {
       expect(fibonacci.getState().sessionActive).toBe(false);
     });
   });
+
+  describe("statistics", () => {
+    it("should initialize statistics on session start", () => {
+      fibonacci.initSession(10);
+      const stats = fibonacci.getStatistics();
+      expect(stats).toBeDefined();
+      expect(stats?.totalGames).toBe(0);
+    });
+
+    it("should update statistics on recordResult", () => {
+      fibonacci.initSession(10);
+      fibonacci.recordResult("loss");
+      const stats = fibonacci.getStatistics();
+      expect(stats?.totalGames).toBe(1);
+      expect(stats?.totalWins).toBe(0);
+      expect(stats?.totalLosses).toBe(1);
+    });
+
+    it("should return undefined when statistics not initialized", () => {
+      const fibonacci2 = new FibonacciMethod();
+      const stats = fibonacci2.getStatistics();
+      expect(stats).toBeUndefined();
+    });
+
+    it("should track bet history", () => {
+      fibonacci.initSession(10);
+      fibonacci.recordResult("loss");
+      fibonacci.recordResult("loss");
+      const stats = fibonacci.getStatistics();
+      expect(stats?.betHistory).toHaveLength(2);
+      expect(stats?.outcomeHistory).toHaveLength(2);
+    });
+
+    it("should return deep copy of history arrays", () => {
+      fibonacci.initSession(10);
+      fibonacci.recordResult("loss");
+      const stats1 = fibonacci.getStatistics();
+      const stats2 = fibonacci.getStatistics();
+      expect(stats1?.betHistory).toEqual(stats2?.betHistory);
+      expect(stats1?.betHistory).not.toBe(stats2?.betHistory);
+      expect(stats1?.outcomeHistory).not.toBe(stats2?.outcomeHistory);
+    });
+
+    it("should handle undefined history arrays", () => {
+      fibonacci.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (fibonacci as any).state.statistics = {
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        ...(fibonacci as any).state.statistics,
+        betHistory: undefined,
+        outcomeHistory: undefined,
+        bankrollHistory: undefined,
+      };
+      const stats = fibonacci.getStatistics();
+      expect(stats?.betHistory).toBeUndefined();
+      expect(stats?.outcomeHistory).toBeUndefined();
+      expect(stats?.bankrollHistory).toBeUndefined();
+    });
+
+    it("should handle defined bankrollHistory", () => {
+      fibonacci.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (fibonacci as any).state.statistics = {
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        ...(fibonacci as any).state.statistics,
+        bankrollHistory: [1000, 1100],
+      };
+      const stats = fibonacci.getStatistics();
+      expect(stats?.bankrollHistory).toEqual([1000, 1100]);
+      expect(stats?.bankrollHistory).not.toBe(
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        (fibonacci as any).state.statistics.bankrollHistory,
+      );
+    });
+
+    it("should initialize statistics if missing in recordResult", () => {
+      fibonacci.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (fibonacci as any).state.statistics = undefined;
+      fibonacci.recordResult("loss");
+      const stats = fibonacci.getStatistics();
+      expect(stats).toBeDefined();
+      expect(stats?.totalGames).toBe(1);
+    });
+  });
 });

--- a/src/methods/__tests__/goodman.test.ts
+++ b/src/methods/__tests__/goodman.test.ts
@@ -331,4 +331,89 @@ describe("GoodmanMethod", () => {
       expect(goodman.getState().cyclesCompleted).toBe(2);
     });
   });
+
+  describe("statistics", () => {
+    it("should initialize statistics on session start", () => {
+      goodman.initSession(10);
+      const stats = goodman.getStatistics();
+      expect(stats).toBeDefined();
+      expect(stats?.totalGames).toBe(0);
+    });
+
+    it("should update statistics on recordResult", () => {
+      goodman.initSession(10);
+      goodman.recordResult("win");
+      const stats = goodman.getStatistics();
+      expect(stats?.totalGames).toBe(1);
+      expect(stats?.totalWins).toBe(1);
+      expect(stats?.totalLosses).toBe(0);
+    });
+
+    it("should return undefined when statistics not initialized", () => {
+      const goodman2 = new GoodmanMethod();
+      const stats = goodman2.getStatistics();
+      expect(stats).toBeUndefined();
+    });
+
+    it("should track bet history", () => {
+      goodman.initSession(10);
+      goodman.recordResult("win");
+      goodman.recordResult("loss");
+      const stats = goodman.getStatistics();
+      expect(stats?.betHistory).toHaveLength(2);
+      expect(stats?.outcomeHistory).toHaveLength(2);
+    });
+
+    it("should return deep copy of history arrays", () => {
+      goodman.initSession(10);
+      goodman.recordResult("win");
+      const stats1 = goodman.getStatistics();
+      const stats2 = goodman.getStatistics();
+      expect(stats1?.betHistory).toEqual(stats2?.betHistory);
+      expect(stats1?.betHistory).not.toBe(stats2?.betHistory);
+      expect(stats1?.outcomeHistory).not.toBe(stats2?.outcomeHistory);
+    });
+
+    it("should handle undefined history arrays", () => {
+      goodman.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (goodman as any).state.statistics = {
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        ...(goodman as any).state.statistics,
+        betHistory: undefined,
+        outcomeHistory: undefined,
+        bankrollHistory: undefined,
+      };
+      const stats = goodman.getStatistics();
+      expect(stats?.betHistory).toBeUndefined();
+      expect(stats?.outcomeHistory).toBeUndefined();
+      expect(stats?.bankrollHistory).toBeUndefined();
+    });
+
+    it("should handle defined bankrollHistory", () => {
+      goodman.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (goodman as any).state.statistics = {
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        ...(goodman as any).state.statistics,
+        bankrollHistory: [1000, 1100],
+      };
+      const stats = goodman.getStatistics();
+      expect(stats?.bankrollHistory).toEqual([1000, 1100]);
+      expect(stats?.bankrollHistory).not.toBe(
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        (goodman as any).state.statistics.bankrollHistory,
+      );
+    });
+
+    it("should initialize statistics if missing in recordResult", () => {
+      goodman.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (goodman as any).state.statistics = undefined;
+      goodman.recordResult("win");
+      const stats = goodman.getStatistics();
+      expect(stats).toBeDefined();
+      expect(stats?.totalGames).toBe(1);
+    });
+  });
 });

--- a/src/methods/__tests__/kelly.test.ts
+++ b/src/methods/__tests__/kelly.test.ts
@@ -484,4 +484,89 @@ describe("KellyCriterionMethod", () => {
       expect(decimalPlaces).toBeLessThanOrEqual(2);
     });
   });
+
+  describe("statistics", () => {
+    it("should initialize statistics on session start", () => {
+      kelly.initSession(1000, 0.55, 2.0);
+      const stats = kelly.getStatistics();
+      expect(stats).toBeDefined();
+      expect(stats?.totalGames).toBe(0);
+    });
+
+    it("should update statistics on recordResult", () => {
+      kelly.initSession(1000, 0.55, 2.0);
+      kelly.recordResult("win");
+      const stats = kelly.getStatistics();
+      expect(stats?.totalGames).toBe(1);
+      expect(stats?.totalWins).toBe(1);
+      expect(stats?.totalLosses).toBe(0);
+    });
+
+    it("should return undefined when statistics not initialized", () => {
+      const kelly2 = new KellyCriterionMethod();
+      const stats = kelly2.getStatistics();
+      expect(stats).toBeUndefined();
+    });
+
+    it("should track bet history", () => {
+      kelly.initSession(1000, 0.55, 2.0);
+      kelly.recordResult("win");
+      kelly.recordResult("loss");
+      const stats = kelly.getStatistics();
+      expect(stats?.betHistory).toHaveLength(2);
+      expect(stats?.outcomeHistory).toHaveLength(2);
+    });
+
+    it("should return deep copy of history arrays", () => {
+      kelly.initSession(1000, 0.55, 2.0);
+      kelly.recordResult("win");
+      const stats1 = kelly.getStatistics();
+      const stats2 = kelly.getStatistics();
+      expect(stats1?.betHistory).toEqual(stats2?.betHistory);
+      expect(stats1?.betHistory).not.toBe(stats2?.betHistory);
+      expect(stats1?.outcomeHistory).not.toBe(stats2?.outcomeHistory);
+    });
+
+    it("should handle undefined history arrays", () => {
+      kelly.initSession(1000, 0.55, 2.0);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (kelly as any).state.statistics = {
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        ...(kelly as any).state.statistics,
+        betHistory: undefined,
+        outcomeHistory: undefined,
+        bankrollHistory: undefined,
+      };
+      const stats = kelly.getStatistics();
+      expect(stats?.betHistory).toBeUndefined();
+      expect(stats?.outcomeHistory).toBeUndefined();
+      expect(stats?.bankrollHistory).toBeUndefined();
+    });
+
+    it("should handle defined bankrollHistory", () => {
+      kelly.initSession(1000, 0.55, 2.0);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (kelly as any).state.statistics = {
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        ...(kelly as any).state.statistics,
+        bankrollHistory: [1000, 1100],
+      };
+      const stats = kelly.getStatistics();
+      expect(stats?.bankrollHistory).toEqual([1000, 1100]);
+      expect(stats?.bankrollHistory).not.toBe(
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        (kelly as any).state.statistics.bankrollHistory,
+      );
+    });
+
+    it("should initialize statistics if missing in recordResult", () => {
+      kelly.initSession(1000, 0.55, 2.0);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (kelly as any).state.statistics = undefined;
+      kelly.recordResult("win");
+      const stats = kelly.getStatistics();
+      expect(stats).toBeDefined();
+      expect(stats?.totalGames).toBe(1);
+    });
+  });
 });

--- a/src/methods/__tests__/paroli.test.ts
+++ b/src/methods/__tests__/paroli.test.ts
@@ -260,4 +260,89 @@ describe("ParoliMethod", () => {
       expect(state2.totalProfit).toBe(310); // 10+20+40+80+160
     });
   });
+
+  describe("statistics", () => {
+    it("should initialize statistics on session start", () => {
+      paroli.initSession(10);
+      const stats = paroli.getStatistics();
+      expect(stats).toBeDefined();
+      expect(stats?.totalGames).toBe(0);
+    });
+
+    it("should update statistics on recordResult", () => {
+      paroli.initSession(10);
+      paroli.recordResult("win");
+      const stats = paroli.getStatistics();
+      expect(stats?.totalGames).toBe(1);
+      expect(stats?.totalWins).toBe(1);
+      expect(stats?.totalLosses).toBe(0);
+    });
+
+    it("should return undefined when statistics not initialized", () => {
+      const paroli2 = new ParoliMethod();
+      const stats = paroli2.getStatistics();
+      expect(stats).toBeUndefined();
+    });
+
+    it("should track bet history", () => {
+      paroli.initSession(10);
+      paroli.recordResult("win");
+      paroli.recordResult("loss");
+      const stats = paroli.getStatistics();
+      expect(stats?.betHistory).toHaveLength(2);
+      expect(stats?.outcomeHistory).toHaveLength(2);
+    });
+
+    it("should return deep copy of history arrays", () => {
+      paroli.initSession(10);
+      paroli.recordResult("win");
+      const stats1 = paroli.getStatistics();
+      const stats2 = paroli.getStatistics();
+      expect(stats1?.betHistory).toEqual(stats2?.betHistory);
+      expect(stats1?.betHistory).not.toBe(stats2?.betHistory);
+      expect(stats1?.outcomeHistory).not.toBe(stats2?.outcomeHistory);
+    });
+
+    it("should handle undefined history arrays", () => {
+      paroli.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (paroli as any).state.statistics = {
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        ...(paroli as any).state.statistics,
+        betHistory: undefined,
+        outcomeHistory: undefined,
+        bankrollHistory: undefined,
+      };
+      const stats = paroli.getStatistics();
+      expect(stats?.betHistory).toBeUndefined();
+      expect(stats?.outcomeHistory).toBeUndefined();
+      expect(stats?.bankrollHistory).toBeUndefined();
+    });
+
+    it("should handle defined bankrollHistory", () => {
+      paroli.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (paroli as any).state.statistics = {
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        ...(paroli as any).state.statistics,
+        bankrollHistory: [1000, 1100],
+      };
+      const stats = paroli.getStatistics();
+      expect(stats?.bankrollHistory).toEqual([1000, 1100]);
+      expect(stats?.bankrollHistory).not.toBe(
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        (paroli as any).state.statistics.bankrollHistory,
+      );
+    });
+
+    it("should initialize statistics if missing in recordResult", () => {
+      paroli.initSession(10);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (paroli as any).state.statistics = undefined;
+      paroli.recordResult("win");
+      const stats = paroli.getStatistics();
+      expect(stats).toBeDefined();
+      expect(stats?.totalGames).toBe(1);
+    });
+  });
 });

--- a/src/methods/__tests__/percentage.test.ts
+++ b/src/methods/__tests__/percentage.test.ts
@@ -317,4 +317,89 @@ describe("PercentageMethod", () => {
       expect(state.profitPercentage).toBeCloseTo(6.5, 1);
     });
   });
+
+  describe("statistics", () => {
+    it("should initialize statistics on session start", () => {
+      percentage.initSession(1000, 0.1, 1);
+      const stats = percentage.getStatistics();
+      expect(stats).toBeDefined();
+      expect(stats?.totalGames).toBe(0);
+    });
+
+    it("should update statistics on recordResult", () => {
+      percentage.initSession(1000, 0.1, 1);
+      percentage.recordResult("win");
+      const stats = percentage.getStatistics();
+      expect(stats?.totalGames).toBe(1);
+      expect(stats?.totalWins).toBe(1);
+      expect(stats?.totalLosses).toBe(0);
+    });
+
+    it("should return undefined when statistics not initialized", () => {
+      const percentage2 = new PercentageMethod();
+      const stats = percentage2.getStatistics();
+      expect(stats).toBeUndefined();
+    });
+
+    it("should track bet history", () => {
+      percentage.initSession(1000, 0.1, 1);
+      percentage.recordResult("win");
+      percentage.recordResult("loss");
+      const stats = percentage.getStatistics();
+      expect(stats?.betHistory).toHaveLength(2);
+      expect(stats?.outcomeHistory).toHaveLength(2);
+    });
+
+    it("should return deep copy of history arrays", () => {
+      percentage.initSession(1000, 0.1, 1);
+      percentage.recordResult("win");
+      const stats1 = percentage.getStatistics();
+      const stats2 = percentage.getStatistics();
+      expect(stats1?.betHistory).toEqual(stats2?.betHistory);
+      expect(stats1?.betHistory).not.toBe(stats2?.betHistory);
+      expect(stats1?.outcomeHistory).not.toBe(stats2?.outcomeHistory);
+    });
+
+    it("should handle undefined history arrays", () => {
+      percentage.initSession(1000, 0.1, 1);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (percentage as any).state.statistics = {
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        ...(percentage as any).state.statistics,
+        betHistory: undefined,
+        outcomeHistory: undefined,
+        bankrollHistory: undefined,
+      };
+      const stats = percentage.getStatistics();
+      expect(stats?.betHistory).toBeUndefined();
+      expect(stats?.outcomeHistory).toBeUndefined();
+      expect(stats?.bankrollHistory).toBeUndefined();
+    });
+
+    it("should handle defined bankrollHistory", () => {
+      percentage.initSession(1000, 0.1, 1);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (percentage as any).state.statistics = {
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        ...(percentage as any).state.statistics,
+        bankrollHistory: [1000, 1100],
+      };
+      const stats = percentage.getStatistics();
+      expect(stats?.bankrollHistory).toEqual([1000, 1100]);
+      expect(stats?.bankrollHistory).not.toBe(
+        // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+        (percentage as any).state.statistics.bankrollHistory,
+      );
+    });
+
+    it("should initialize statistics if missing in recordResult", () => {
+      percentage.initSession(1000, 0.1, 1);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private state access
+      (percentage as any).state.statistics = undefined;
+      percentage.recordResult("win");
+      const stats = percentage.getStatistics();
+      expect(stats).toBeDefined();
+      expect(stats?.totalGames).toBe(1);
+    });
+  });
 });

--- a/src/methods/cocomo.ts
+++ b/src/methods/cocomo.ts
@@ -1,4 +1,9 @@
-import type { BetResult, CocomoState } from "../types.js";
+import type { BetResult, CocomoState, SessionStatistics } from "../types.js";
+import {
+  calculateRiskMetrics,
+  initializeStatistics,
+  updateStatistics,
+} from "../utils/statistics.js";
 
 /**
  * Cocomo betting method calculator
@@ -46,6 +51,7 @@ export class CocomoMethod {
       sessionActive: true,
       reachedLimit: false,
       payoutMultiplier: 3,
+      statistics: initializeStatistics(),
     };
 
     // Validate maxBet
@@ -63,6 +69,18 @@ export class CocomoMethod {
     }
 
     const currentBetAmount = this.state.currentBet;
+
+    // Update statistics
+    if (!this.state.statistics) {
+      this.state.statistics = initializeStatistics();
+    }
+    const payout = result === "win" ? currentBetAmount * 3 : 0;
+    this.state.statistics = updateStatistics(
+      this.state.statistics,
+      currentBetAmount,
+      result,
+      payout,
+    );
 
     if (result === "win") {
       // Win: 3x payout, minus the bet amount itself = 2x net profit
@@ -101,6 +119,9 @@ export class CocomoMethod {
       this.state.previousBet = currentBetAmount;
       this.state.currentBet = nextBet;
     }
+
+    // Update risk metrics
+    this.state.statistics = calculateRiskMetrics(this.state.statistics);
   }
 
   /**
@@ -108,6 +129,27 @@ export class CocomoMethod {
    */
   getState(): CocomoState {
     return { ...this.state };
+  }
+
+  /**
+   * Get statistics for the current session
+   */
+  getStatistics(): SessionStatistics | undefined {
+    if (!this.state.statistics) {
+      return undefined;
+    }
+    return {
+      ...this.state.statistics,
+      betHistory: this.state.statistics.betHistory
+        ? [...this.state.statistics.betHistory]
+        : undefined,
+      outcomeHistory: this.state.statistics.outcomeHistory
+        ? [...this.state.statistics.outcomeHistory]
+        : undefined,
+      bankrollHistory: this.state.statistics.bankrollHistory
+        ? [...this.state.statistics.bankrollHistory]
+        : undefined,
+    };
   }
 
   /**

--- a/src/methods/dalembert.ts
+++ b/src/methods/dalembert.ts
@@ -1,4 +1,9 @@
-import type { BetResult, DAlembertState } from "../types.js";
+import type { BetResult, DAlembertState, SessionStatistics } from "../types.js";
+import {
+  calculateRiskMetrics,
+  initializeStatistics,
+  updateStatistics,
+} from "../utils/statistics.js";
 
 /**
  * D'Alembert betting method calculator
@@ -39,6 +44,7 @@ export class DAlembertMethod {
       totalProfit: 0,
       sessionActive: true,
       reachedLimit: false,
+      statistics: initializeStatistics(),
     };
 
     // Validate maxBet
@@ -56,6 +62,18 @@ export class DAlembertMethod {
     }
 
     const currentBetAmount = this.state.currentBet;
+
+    // Update statistics
+    if (!this.state.statistics) {
+      this.state.statistics = initializeStatistics();
+    }
+    const payout = result === "win" ? currentBetAmount * 2 : 0;
+    this.state.statistics = updateStatistics(
+      this.state.statistics,
+      currentBetAmount,
+      result,
+      payout,
+    );
 
     if (result === "win") {
       // Update profit
@@ -80,6 +98,9 @@ export class DAlembertMethod {
 
       this.state.currentBet = nextBet;
     }
+
+    // Update risk metrics
+    this.state.statistics = calculateRiskMetrics(this.state.statistics);
   }
 
   /**
@@ -87,6 +108,27 @@ export class DAlembertMethod {
    */
   getState(): DAlembertState {
     return { ...this.state };
+  }
+
+  /**
+   * Get statistics for the current session
+   */
+  getStatistics(): SessionStatistics | undefined {
+    if (!this.state.statistics) {
+      return undefined;
+    }
+    return {
+      ...this.state.statistics,
+      betHistory: this.state.statistics.betHistory
+        ? [...this.state.statistics.betHistory]
+        : undefined,
+      outcomeHistory: this.state.statistics.outcomeHistory
+        ? [...this.state.statistics.outcomeHistory]
+        : undefined,
+      bankrollHistory: this.state.statistics.bankrollHistory
+        ? [...this.state.statistics.bankrollHistory]
+        : undefined,
+    };
   }
 
   /**

--- a/src/methods/fibonacci.ts
+++ b/src/methods/fibonacci.ts
@@ -1,4 +1,9 @@
-import type { BetResult, FibonacciState } from "../types.js";
+import type { BetResult, FibonacciState, SessionStatistics } from "../types.js";
+import {
+  calculateRiskMetrics,
+  initializeStatistics,
+  updateStatistics,
+} from "../utils/statistics.js";
 
 /**
  * Fibonacci betting method calculator
@@ -67,6 +72,7 @@ export class FibonacciMethod {
       totalProfit: 0,
       sessionActive: true,
       reachedLimit: false,
+      statistics: initializeStatistics(),
     };
   }
 
@@ -79,6 +85,18 @@ export class FibonacciMethod {
     }
 
     const currentBetAmount = this.state.currentBet;
+
+    // Update statistics
+    if (!this.state.statistics) {
+      this.state.statistics = initializeStatistics();
+    }
+    const payout = result === "win" ? currentBetAmount * 2 : 0;
+    this.state.statistics = updateStatistics(
+      this.state.statistics,
+      currentBetAmount,
+      result,
+      payout,
+    );
 
     if (result === "win") {
       // Update profit
@@ -115,6 +133,9 @@ export class FibonacciMethod {
       this.state.currentIndex = newIndex;
       this.state.currentBet = this.state.sequence[newIndex] * this.state.baseUnit;
     }
+
+    // Update risk metrics
+    this.state.statistics = calculateRiskMetrics(this.state.statistics);
   }
 
   /**
@@ -122,6 +143,27 @@ export class FibonacciMethod {
    */
   getState(): FibonacciState {
     return { ...this.state };
+  }
+
+  /**
+   * Get statistics for the current session
+   */
+  getStatistics(): SessionStatistics | undefined {
+    if (!this.state.statistics) {
+      return undefined;
+    }
+    return {
+      ...this.state.statistics,
+      betHistory: this.state.statistics.betHistory
+        ? [...this.state.statistics.betHistory]
+        : undefined,
+      outcomeHistory: this.state.statistics.outcomeHistory
+        ? [...this.state.statistics.outcomeHistory]
+        : undefined,
+      bankrollHistory: this.state.statistics.bankrollHistory
+        ? [...this.state.statistics.bankrollHistory]
+        : undefined,
+    };
   }
 
   /**

--- a/src/methods/goodman.ts
+++ b/src/methods/goodman.ts
@@ -1,4 +1,9 @@
-import type { BetResult, GoodmanState } from "../types.js";
+import type { BetResult, GoodmanState, SessionStatistics } from "../types.js";
+import {
+  calculateRiskMetrics,
+  initializeStatistics,
+  updateStatistics,
+} from "../utils/statistics.js";
 
 /**
  * Goodman betting method calculator (1-2-3-5 method)
@@ -42,6 +47,7 @@ export class GoodmanMethod {
       totalProfit: 0,
       sessionActive: true,
       cyclesCompleted: 0,
+      statistics: initializeStatistics(),
     };
   }
 
@@ -54,6 +60,18 @@ export class GoodmanMethod {
     }
 
     const currentBetAmount = this.state.currentBet;
+
+    // Update statistics
+    if (!this.state.statistics) {
+      this.state.statistics = initializeStatistics();
+    }
+    const payout = result === "win" ? currentBetAmount * 2 : 0;
+    this.state.statistics = updateStatistics(
+      this.state.statistics,
+      currentBetAmount,
+      result,
+      payout,
+    );
 
     if (result === "win") {
       // Update profit
@@ -85,6 +103,9 @@ export class GoodmanMethod {
       this.state.winStreak = 0;
       this.state.currentBet = this.state.sequence[0] * this.state.baseUnit;
     }
+
+    // Update risk metrics
+    this.state.statistics = calculateRiskMetrics(this.state.statistics);
   }
 
   /**
@@ -94,6 +115,27 @@ export class GoodmanMethod {
     return {
       ...this.state,
       sequence: [...this.state.sequence], // Deep copy of array
+    };
+  }
+
+  /**
+   * Get statistics for the current session
+   */
+  getStatistics(): SessionStatistics | undefined {
+    if (!this.state.statistics) {
+      return undefined;
+    }
+    return {
+      ...this.state.statistics,
+      betHistory: this.state.statistics.betHistory
+        ? [...this.state.statistics.betHistory]
+        : undefined,
+      outcomeHistory: this.state.statistics.outcomeHistory
+        ? [...this.state.statistics.outcomeHistory]
+        : undefined,
+      bankrollHistory: this.state.statistics.bankrollHistory
+        ? [...this.state.statistics.bankrollHistory]
+        : undefined,
     };
   }
 

--- a/src/methods/kelly.ts
+++ b/src/methods/kelly.ts
@@ -1,4 +1,9 @@
-import type { BetResult, KellyCriterionState } from "../types.js";
+import type { BetResult, KellyCriterionState, SessionStatistics } from "../types.js";
+import {
+  calculateRiskMetrics,
+  initializeStatistics,
+  updateStatistics,
+} from "../utils/statistics.js";
 
 /**
  * Kelly Criterion betting method calculator
@@ -98,6 +103,7 @@ export class KellyCriterionMethod {
       ),
       totalProfit: 0,
       sessionActive: true,
+      statistics: initializeStatistics(),
     };
   }
 
@@ -156,6 +162,18 @@ export class KellyCriterionMethod {
 
     const currentBet = this.state.currentBet;
 
+    // Update statistics
+    if (!this.state.statistics) {
+      this.state.statistics = initializeStatistics();
+    }
+    const statsPayout = result === "win" ? (actualPayout ?? currentBet * this.state.payoutOdds) : 0;
+    this.state.statistics = updateStatistics(
+      this.state.statistics,
+      currentBet,
+      result,
+      statsPayout,
+    );
+
     if (currentBet <= 0) {
       throw new Error("Cannot record result: recommended bet is 0 or negative");
     }
@@ -205,6 +223,9 @@ export class KellyCriterionMethod {
       this.state.maxBet,
     );
 
+    // Update risk metrics
+    this.state.statistics = calculateRiskMetrics(this.state.statistics);
+
     // End session if bankroll is too low
     if (this.state.currentBankroll < this.state.minBet) {
       this.state.sessionActive = false;
@@ -219,6 +240,27 @@ export class KellyCriterionMethod {
     return {
       ...this.state,
       bankrollHistory: [...this.state.bankrollHistory], // Deep copy
+    };
+  }
+
+  /**
+   * Get statistics for the current session
+   */
+  getStatistics(): SessionStatistics | undefined {
+    if (!this.state.statistics) {
+      return undefined;
+    }
+    return {
+      ...this.state.statistics,
+      betHistory: this.state.statistics.betHistory
+        ? [...this.state.statistics.betHistory]
+        : undefined,
+      outcomeHistory: this.state.statistics.outcomeHistory
+        ? [...this.state.statistics.outcomeHistory]
+        : undefined,
+      bankrollHistory: this.state.statistics.bankrollHistory
+        ? [...this.state.statistics.bankrollHistory]
+        : undefined,
     };
   }
 

--- a/src/methods/paroli.ts
+++ b/src/methods/paroli.ts
@@ -1,4 +1,9 @@
-import type { BetResult, ParoliState } from "../types.js";
+import type { BetResult, ParoliState, SessionStatistics } from "../types.js";
+import {
+  calculateRiskMetrics,
+  initializeStatistics,
+  updateStatistics,
+} from "../utils/statistics.js";
 
 /**
  * Paroli betting method calculator (Reverse Martingale)
@@ -45,6 +50,7 @@ export class ParoliMethod {
       totalProfit: 0,
       sessionActive: true,
       cyclesCompleted: 0,
+      statistics: initializeStatistics(),
     };
   }
 
@@ -57,6 +63,18 @@ export class ParoliMethod {
     }
 
     const currentBetAmount = this.state.currentBet;
+
+    // Update statistics
+    if (!this.state.statistics) {
+      this.state.statistics = initializeStatistics();
+    }
+    const payout = result === "win" ? currentBetAmount * 2 : 0;
+    this.state.statistics = updateStatistics(
+      this.state.statistics,
+      currentBetAmount,
+      result,
+      payout,
+    );
 
     if (result === "win") {
       // Update profit
@@ -83,6 +101,9 @@ export class ParoliMethod {
       this.state.currentBet = this.state.baseUnit;
       this.state.winStreak = 0;
     }
+
+    // Update risk metrics
+    this.state.statistics = calculateRiskMetrics(this.state.statistics);
   }
 
   /**
@@ -90,6 +111,27 @@ export class ParoliMethod {
    */
   getState(): ParoliState {
     return { ...this.state };
+  }
+
+  /**
+   * Get statistics for the current session
+   */
+  getStatistics(): SessionStatistics | undefined {
+    if (!this.state.statistics) {
+      return undefined;
+    }
+    return {
+      ...this.state.statistics,
+      betHistory: this.state.statistics.betHistory
+        ? [...this.state.statistics.betHistory]
+        : undefined,
+      outcomeHistory: this.state.statistics.outcomeHistory
+        ? [...this.state.statistics.outcomeHistory]
+        : undefined,
+      bankrollHistory: this.state.statistics.bankrollHistory
+        ? [...this.state.statistics.bankrollHistory]
+        : undefined,
+    };
   }
 
   /**

--- a/src/methods/percentage.ts
+++ b/src/methods/percentage.ts
@@ -1,4 +1,9 @@
-import type { BetResult, PercentageState } from "../types.js";
+import type { BetResult, PercentageState, SessionStatistics } from "../types.js";
+import {
+  calculateRiskMetrics,
+  initializeStatistics,
+  updateStatistics,
+} from "../utils/statistics.js";
 
 /**
  * Percentage (Fixed Percentage Betting) method calculator
@@ -68,6 +73,7 @@ export class PercentageMethod {
       totalProfit: 0,
       sessionActive: true,
       profitPercentage: 0,
+      statistics: initializeStatistics(),
     };
   }
 
@@ -80,6 +86,18 @@ export class PercentageMethod {
     }
 
     const currentBetAmount = this.state.currentBet;
+
+    // Update statistics
+    if (!this.state.statistics) {
+      this.state.statistics = initializeStatistics();
+    }
+    const payout = result === "win" ? currentBetAmount * 2 : 0;
+    this.state.statistics = updateStatistics(
+      this.state.statistics,
+      currentBetAmount,
+      result,
+      payout,
+    );
 
     if (result === "win") {
       // Update bankroll and profit
@@ -110,6 +128,9 @@ export class PercentageMethod {
       this.state.minBet,
       Math.floor(this.state.currentBankroll * this.state.betPercentage),
     );
+
+    // Update risk metrics
+    this.state.statistics = calculateRiskMetrics(this.state.statistics);
   }
 
   /**
@@ -117,6 +138,27 @@ export class PercentageMethod {
    */
   getState(): PercentageState {
     return { ...this.state };
+  }
+
+  /**
+   * Get statistics for the current session
+   */
+  getStatistics(): SessionStatistics | undefined {
+    if (!this.state.statistics) {
+      return undefined;
+    }
+    return {
+      ...this.state.statistics,
+      betHistory: this.state.statistics.betHistory
+        ? [...this.state.statistics.betHistory]
+        : undefined,
+      outcomeHistory: this.state.statistics.outcomeHistory
+        ? [...this.state.statistics.outcomeHistory]
+        : undefined,
+      bankrollHistory: this.state.statistics.bankrollHistory
+        ? [...this.state.statistics.bankrollHistory]
+        : undefined,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

- 残り7メソッド（Cocomo, Goodman, Fibonacci, Paroli, D'Alembert, Percentage, Kelly Criterion）に統計レポート機能を追加
- 全11メソッドで `{method}_statistics` ツールが利用可能に
- 統計内容: 勝率、ROI、ストリーク、ベット分析、リスク指標（ボラティリティ、シャープレシオ）

## Changes

- 7メソッドに `getStatistics()` メソッド追加（`initializeStatistics`, `updateStatistics`, `calculateRiskMetrics` を使用）
- `src/index.ts` に7つの `{method}_statistics` ツール定義とハンドラを追加
- 7テストファイルに統計テストブロック追加（各8テスト、計56テスト追加）

## Test plan
- [x] `npm run build` - TypeScriptコンパイル成功
- [x] `npm test` - 438テスト全通過（382 → 438、+56）
- [x] `npm run test:coverage` - 100%カバレッジ（statements, branches, functions, lines）
- [x] `npm run check` - Biome lint + format 通過

Closes #61, closes #62, closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)