### PR TITLE
ci: release-pleaseとnpm自動公開ワークフローの追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [22, 24]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint check
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,22 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          release-type: node


### PR DESCRIPTION
## 概要
- **release-please** ワークフローを追加: Conventional Commitsに基づく自動バージョニング、CHANGELOG生成、GitHubリリース作成
- **npm publish** ワークフローを追加: GitHubリリース作成をトリガーに、CI全チェック（lint, format, build, test）通過後にnpmへ公開
- CI Node.jsテストマトリクスを `[18, 20, 22]` → `[22, 24]` に更新（`engines.node: ">=22"` に合わせて）

## リリースフロー
1. Conventional Commits（`feat:`, `fix:`, `chore:` 等）をmainにpush
2. **release-please** がRelease PRを自動作成・更新（バージョンバンプ + CHANGELOG）
3. Release PRをマージ → GitHubリリース + タグが自動作成
4. **publish.yml** がリリースをトリガーにビルド・テスト・npm publish実行

## 必要な設定
- リポジトリのSecrets に `NPM_TOKEN` を追加（Settings → Secrets → Actions）

## テスト計画
- [ ] release-pleaseワークフローがmainへのpushでトリガーされることを確認
- [ ] publishワークフローがリリース作成でトリガーされることを確認
- [ ] `NPM_TOKEN` シークレットを追加してリリースサイクルをテスト
- [ ] CIマトリクスがNode 22, 24で実行されることを確認

Closes #35
Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)